### PR TITLE
Allow initialization from Data and String values directly

### DIFF
--- a/Sources/INIParser/INIParser.swift
+++ b/Sources/INIParser/INIParser.swift
@@ -136,17 +136,36 @@ public class INIParser {
     }
     return ContentType.Assignment(v, cache)
   }
-  /// Constructor
+
+  /// Convenience constructor
   /// - parameters:
   ///   - path: path of INI file to load
   /// - throws:
   ///   Exception
-  public init(_ path: String) throws {
-    let data = try Data(contentsOf: URL(fileURLWithPath: path))
+  public convenience init(_ path: String) throws {
+     let data = try Data(contentsOf: URL(fileURLWithPath: path))
+    try self.init(data: data)
+  }
+
+  /// Convenience constructor
+  /// - parameters:
+  ///   - data: Data of an INI file
+  /// - throws:
+  ///   Exception
+  public convenience init(data: Data) throws {
     guard let text = String(bytes: data, encoding: .utf8) else {
       throw Exception.InvalidFile
     }
-    let lines: [String] = text.split(separator: "\n").map { String($0) }
+    try self.init(string: text)
+  }
+
+  /// Convenience constructor
+  /// - parameters:
+  ///   - string: String content of an INI file
+  /// - throws:
+  ///   Exception
+  public init(string: String) throws {
+    let lines: [String] = string.split(separator: "\n").map { String($0) }
     var title: String? = nil
     for line in lines {
       if let content = try parse(line: line) {

--- a/Sources/INIParser/INIParser.swift
+++ b/Sources/INIParser/INIParser.swift
@@ -159,7 +159,7 @@ public class INIParser {
     try self.init(string: text)
   }
 
-  /// Convenience constructor
+  /// Constructor
   /// - parameters:
   ///   - string: String content of an INI file
   /// - throws:


### PR DESCRIPTION
I want to use this parser in a project where I have the INI file contents already loaded as a Data object, but as it is currently, its initializer only accepts a file path string. These changes change the current sole initializer:

```swift
  public init(_ path: String) throws 
```

Into the following set of initializers:

``` swift
  public convenience init(_ path: String) throws 
  public convenience init(data: Data) throws 
  public init(string: String) throws 
```

Existing code will continue to work.