### PR TITLE
Added support for files originating from DOS/Windows

### DIFF
--- a/Sources/INIParser/INIParser.swift
+++ b/Sources/INIParser/INIParser.swift
@@ -165,7 +165,7 @@ public class INIParser {
   /// - throws:
   ///   Exception
   public init(string: String) throws {
-    let lines: [String] = string.split(separator: "\n").map { String($0) }
+    let lines: [String] = string.components(separatedBy: .newlines).compactMap{$0.isEmpty ? nil : $0}
     var title: String? = nil
     for line in lines {
       if let content = try parse(line: line) {

--- a/Tests/INIParserTests/INIParserTests.swift
+++ b/Tests/INIParserTests/INIParserTests.swift
@@ -32,8 +32,8 @@ class INIParserTests: XCTestCase {
       freeVar1 = 1
       freeVar2 = 2;
       url = http://example.com/results?limit=10
-      [owner]
-      name =  Rocky
+      [owner]\r
+      name =  Rocky\r
       organization = PerfectlySoft
       ;
       [database]


### PR DESCRIPTION
Files coming from DOS/Windows systems have `\r\n` line terminations, which lead to incorrect parsing in the initializer. This PR fixes that problem. I also added a simple test case.